### PR TITLE
resolver

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -6,5 +6,6 @@ pub mod interpreter;
 pub mod lexer;
 pub mod object;
 pub mod parser;
+pub mod resolver;
 
 pub type LoxFloat = f64;

--- a/src/compiler/environment.rs
+++ b/src/compiler/environment.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Formatter};
 use std::rc::Rc;
 
 use crate::compiler::interpreter::RuntimeError;
-use crate::compiler::lexer::{Literal, Token};
+use crate::compiler::lexer::Token;
 use crate::compiler::object::LoxValue;
 
 #[derive(PartialEq, Clone)]
@@ -15,7 +15,7 @@ pub struct Environment {
 
 impl Environment {
     pub fn get(&self, name: &Token) -> Result<LoxValue, RuntimeError> {
-        match self.data.get(&Self::get_ident(&name)) {
+        match self.data.get(&name.ident()) {
             Some(obj) => Ok(obj.clone()),
             None => match &self.enclosing {
                 Some(enc) => enc.borrow().get(&name),
@@ -25,14 +25,14 @@ impl Environment {
     }
 
     pub fn set(&mut self, name: &Token, value: LoxValue) {
-        let _ = &self.data.insert(Self::get_ident(&name), value);
+        let _ = &self.data.insert(name.ident(), value);
     }
 
     pub fn update(&mut self, name: &Token, value: LoxValue) -> Result<(), RuntimeError> {
-        let has_key = &self.data.contains_key(&Self::get_ident(&name));
+        let has_key = &self.data.contains_key(&name.ident());
         match has_key {
             true => {
-                let _ = &self.data.insert(Self::get_ident(&name), value);
+                let _ = &self.data.insert(name.ident(), value);
                 Ok(())
             }
             false => match &mut self.enclosing {
@@ -53,17 +53,6 @@ impl Environment {
         Environment {
             data: HashMap::new(),
             enclosing: Some(enclosing),
-        }
-    }
-
-    fn get_ident(name: &Token) -> String {
-        match name
-            .literal
-            .as_ref()
-            .expect("Attempt to get name from invalid token type!")
-        {
-            Literal::Ident(id) => id.to_string(),
-            _ => panic!("Attempt to get name from invalid token type!"),
         }
     }
 }

--- a/src/compiler/environment.rs
+++ b/src/compiler/environment.rs
@@ -24,6 +24,33 @@ impl Environment {
         }
     }
 
+    pub fn get_at(&self, distance: usize, name: &Token) -> LoxValue {
+        if distance > 0 {
+            return self
+                .enclosing
+                .clone()
+                .expect("should not be at global for get_at")
+                .borrow()
+                .get_at(distance - 1, name);
+        }
+        self.data
+            .get(name.ident())
+            .expect("value should exist")
+            .clone()
+    }
+
+    pub fn set_at(&mut self, distance: usize, name: &Token, value: LoxValue) {
+        if distance > 0 {
+            return self
+                .enclosing
+                .clone()
+                .expect("should not be at global for set_at")
+                .borrow_mut()
+                .set_at(distance - 1, name, value);
+        }
+        self.set(name, value);
+    }
+
     pub fn set(&mut self, name: &Token, value: LoxValue) {
         let _ = &self.data.insert(name.ident().to_string(), value);
     }

--- a/src/compiler/environment.rs
+++ b/src/compiler/environment.rs
@@ -15,7 +15,7 @@ pub struct Environment {
 
 impl Environment {
     pub fn get(&self, name: &Token) -> Result<LoxValue, RuntimeError> {
-        match self.data.get(&name.ident()) {
+        match self.data.get(name.ident()) {
             Some(obj) => Ok(obj.clone()),
             None => match &self.enclosing {
                 Some(enc) => enc.borrow().get(&name),
@@ -25,14 +25,14 @@ impl Environment {
     }
 
     pub fn set(&mut self, name: &Token, value: LoxValue) {
-        let _ = &self.data.insert(name.ident(), value);
+        let _ = &self.data.insert(name.ident().to_string(), value);
     }
 
     pub fn update(&mut self, name: &Token, value: LoxValue) -> Result<(), RuntimeError> {
-        let has_key = &self.data.contains_key(&name.ident());
+        let has_key = &self.data.contains_key(name.ident());
         match has_key {
             true => {
-                let _ = &self.data.insert(name.ident(), value);
+                let _ = &self.data.insert(name.ident().to_string(), value);
                 Ok(())
             }
             false => match &mut self.enclosing {

--- a/src/compiler/interpreter.rs
+++ b/src/compiler/interpreter.rs
@@ -900,6 +900,13 @@ mod tests {
     }
 
     #[test]
+    fn static_scope() {
+        let static_scope =
+            std::fs::read_to_string("tests/static_scope.lox").expect("file should exist");
+        test_output(static_scope.as_str(), "global\nglobal\n")
+    }
+
+    #[test]
     fn test_cond_true() {
         // most basic conditional
         test_output("if (true) print 1;", "1\n");

--- a/src/compiler/interpreter.rs
+++ b/src/compiler/interpreter.rs
@@ -9,9 +9,7 @@ use crate::compiler::{
     resolver::Resolver,
 };
 
-use std::cell::RefCell;
-use std::io::Write;
-use std::rc::Rc;
+use std::{cell::RefCell, collections::HashMap, io::Write, rc::Rc};
 
 #[derive(Debug, PartialEq)]
 pub enum RuntimeError {
@@ -37,6 +35,7 @@ pub enum RuntimeError {
 
 pub struct Interpreter {
     pub globals: Rc<RefCell<Environment>>,
+    locals: HashMap<Expr, usize>,
     out: Vec<u8>,
     flush: bool,
     print_expr: bool,
@@ -69,10 +68,15 @@ impl Interpreter {
         }
         Interpreter {
             globals,
+            locals: HashMap::new(),
             out: vec![],
             flush: false,
             print_expr: false,
         }
+    }
+
+    pub fn resolve(&mut self, expr: Expr, depth: usize) {
+        self.locals.insert(expr, depth);
     }
 
     pub fn flush(&mut self) {

--- a/src/compiler/interpreter.rs
+++ b/src/compiler/interpreter.rs
@@ -6,6 +6,7 @@ use crate::compiler::{
     lexer::{Literal, Token, TokenType},
     object::LoxValue,
     parser::{Expr, Program, Stmt},
+    resolver::Resolver,
 };
 
 use std::cell::RefCell;
@@ -1008,6 +1009,9 @@ mod tests {
         let program = parser::program(tokens, source.to_string());
         assert!(&program.errors.is_empty());
         let mut interp = interpreter::Interpreter::new();
+        let mut res = Resolver::new(&interp);
+        res.resolve(&program.statements);
+        assert!(res.errors.is_empty());
         interp.set_flush(false);
         interp.run(&program);
         assert_eq!(interp.out, expected.as_bytes());
@@ -1060,6 +1064,9 @@ mod tests {
         let tokens = lexer::scan_source(&fn_decl.to_string()).unwrap();
         let program = parser::program(tokens, fn_decl.to_string());
         let mut interp = interpreter::Interpreter::new();
+        let mut res = Resolver::new(&interp);
+        res.resolve(&program.statements);
+        assert!(res.errors.is_empty());
         interp.set_flush(false);
         interp.run(&program);
 

--- a/src/compiler/interpreter.rs
+++ b/src/compiler/interpreter.rs
@@ -6,7 +6,6 @@ use crate::compiler::{
     lexer::{Literal, Token, TokenType},
     object::LoxValue,
     parser::{Expr, Program, Stmt},
-    resolver::Resolver,
 };
 
 use std::{cell::RefCell, collections::HashMap, io::Write, rc::Rc};
@@ -491,6 +490,7 @@ mod tests {
     use crate::interpreter;
     use crate::lexer::{self, token_iter};
     use crate::parser;
+    use crate::resolver::Resolver;
     use std::fmt::Debug;
 
     #[test]
@@ -864,6 +864,14 @@ mod tests {
         test_output(
             "var a = 7; var b = 5; { var a = 1; print a; {var a = 2; print a; print b;}} print a;",
             "1\n2\n5\n7\n",
+        );
+    }
+
+    #[test]
+    fn resolver_scopes() {
+        test_output(
+"var a = 1; print a; { var a = 2; print a; {var a = 3; print a; {var a = 4; print a; } print a; } print a; } print a;",
+            "1\n2\n3\n4\n3\n2\n1\n",
         );
     }
 

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types, unused)]
-use std::collections::HashMap;
-use std::fmt::{Debug, Display, Formatter};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display, Formatter},
+    hash::{Hash, Hasher},
+};
 
 use thiserror::Error;
 
@@ -106,6 +109,14 @@ pub struct Token {
     pub loc: (usize, usize),
     pub literal: Option<Literal>,
 }
+
+use std::hash::{Hash, Hasher};
+impl Hash for Token {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.loc.hash(state);
+    }
+}
+
 
 /// Convenience / helper functions for quickly creating tokens for use in testing
 impl Token {
@@ -390,6 +401,8 @@ impl PartialEq for Token {
         (self.type_ == other.type_) & (self.literal == other.literal)
     }
 }
+
+impl Eq for Token {}
 
 /// for testing purposes
 pub fn token_iter(source: &str) -> std::iter::Peekable<std::vec::IntoIter<Token>> {

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -144,6 +144,19 @@ impl Token {
         let results = scan_source(&source.to_string()).expect("Invalid Token!");
         results.get(0).expect("No tokens found!").to_owned()
     }
+
+    /// For an IDENTIFIER token, get the name of the identifier.
+    /// Panic if called on a non-identifier token.
+    pub fn ident(&self) -> String {
+        match &self
+            .literal
+            .as_ref()
+            .expect("Attempt to get name from invalid token type!")
+        {
+            Literal::Ident(id) => id.to_string(),
+            _ => panic!("Attempt to get name from invalid token type!"),
+        }
+    }
 }
 
 impl Default for Token {

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -147,13 +147,13 @@ impl Token {
 
     /// For an IDENTIFIER token, get the name of the identifier.
     /// Panic if called on a non-identifier token.
-    pub fn ident(&self) -> String {
+    pub fn ident(&self) -> &String {
         match &self
             .literal
             .as_ref()
             .expect("Attempt to get name from invalid token type!")
         {
-            Literal::Ident(id) => id.to_string(),
+            Literal::Ident(id) => id,
             _ => panic!("Attempt to get name from invalid token type!"),
         }
     }

--- a/src/compiler/lexer.rs
+++ b/src/compiler/lexer.rs
@@ -110,13 +110,11 @@ pub struct Token {
     pub literal: Option<Literal>,
 }
 
-use std::hash::{Hash, Hasher};
 impl Hash for Token {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.loc.hash(state);
     }
 }
-
 
 /// Convenience / helper functions for quickly creating tokens for use in testing
 impl Token {

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -60,7 +60,7 @@ pub enum Stmt {
     Return(Expr),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub enum Expr {
     Literal(Token),
     Unary {

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -1,13 +1,14 @@
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap};
 
 use crate::compiler::{
     interpreter::Interpreter,
+    lexer::Token,
     parser::{Expr, Stmt},
 };
 
 struct Resolver {
     interpreter: Interpreter,
-    scopes: Vec<HashMap<String, bool>>,
+    scopes: Vec<RefCell<HashMap<String, bool>>>,
 }
 
 impl Resolver {
@@ -15,11 +16,88 @@ impl Resolver {
         todo!();
     }
 
+    pub fn resolve_stmt(&mut self, statement: &Stmt) {
+        match statement {
+            Stmt::Block(stmts) => {
+                self.begin_scope();
+                for stmt in stmts.iter() {
+                    self.resolve_stmt(stmt);
+                }
+                self.end_scope();
+            }
+            Stmt::VarDecl { name, initializer } => {
+                self.declare(name);
+                match initializer {
+                    Some(expr) => self.resolve_expr(expr),
+                    None => {}
+                };
+                self.define(name);
+            }
+            Stmt::Expression(expr) => {
+                self.resolve_expr(expr);
+            }
+            Stmt::FunDecl {
+                name,
+                parameters,
+                statements,
+            } => {
+                self.declare(name);
+                self.define(name);
+                self.begin_scope();
+                for param in parameters.iter() {
+                    self.declare(param);
+                    self.define(param);
+                }
+                self.resolve_stmt(statements);
+                self.end_scope();
+            }
+            _ => todo!(),
+        }
+    }
+
+    pub fn resolve_expr(&mut self, expression: &Expr) {
+        match expression {
+            Expr::Variable(var) => {
+                match &self.scopes.last() {
+                    Some(scope) => match scope.borrow().get(var.ident()) {
+                        Some(_) => {},
+                        None => todo!("Need proper error hanLIng for reading local variable within its own initializer"),
+                    }
+                    None => {},
+                }
+                self.resolve_local(expression, &var.ident());
+            }
+            Expr::Assign { name, value } => {
+                self.resolve_expr(value);
+                self.resolve_local(expression, name.ident());
+            }
+            _ => todo!(),
+        }
+    }
+
+    fn resolve_local(&mut self, expression: &Expr, name: &String) {
+        todo!()
+    }
+
     fn begin_scope(&mut self) {
-        &self.scopes.push(HashMap::new());
+        let _ = &self.scopes.push(RefCell::new(HashMap::new()));
     }
 
     fn end_scope(&mut self) {
         let _ = &self.scopes.pop();
+    }
+
+    fn declare(&self, name: &Token) {
+        match self.scopes.last() {
+            Some(scope) => scope.borrow_mut().insert(name.ident().to_string(), false),
+            None => return,
+        };
+    }
+
+    fn define(&self, name: &Token) {
+        match self.scopes.last() {
+            Some(scope) => scope.borrow_mut().insert(name.ident().to_string(), true),
+            None => panic!("Attempt to define undeclared name: {}", name.ident()),
+        };
     }
 }

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use crate::compiler::{
+    interpreter::Interpreter,
+    parser::{Expr, Stmt},
+};
+
+struct Resolver {
+    interpreter: Interpreter,
+    scopes: Vec<HashMap<String, bool>>,
+}
+
+impl Resolver {
+    pub fn resolve(&self, statements: Vec<Stmt>) {
+        todo!();
+    }
+
+    fn begin_scope(&mut self) {
+        &self.scopes.push(HashMap::new());
+    }
+
+    fn end_scope(&mut self) {
+        let _ = &self.scopes.pop();
+    }
+}

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -104,7 +104,7 @@ impl<'a> Resolver<'a> {
             Expr::Variable(var) => {
                 if self
                     .scopes
-                    .first()
+                    .last()
                     .is_some_and(|s| s.borrow().get(var.ident()).is_some_and(|t| !*t))
                 {
                     return Err(ResolverError::OwnInitializer(var.clone()));
@@ -162,7 +162,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn declare(&self, name: &Token) -> Result<(), ResolverError> {
-        match self.scopes.first() {
+        match self.scopes.last() {
             Some(scope) => {
                 if scope.borrow().get(name.ident()).is_some() {
                     return Err(ResolverError::Redefinition(name.clone()));
@@ -175,7 +175,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn define(&self, name: &Token) {
-        match self.scopes.first() {
+        match self.scopes.last() {
             Some(scope) => scope.borrow_mut().insert(name.ident().to_string(), true),
             None => return,
         };

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -6,7 +6,7 @@ use crate::compiler::{
     parser::{Expr, Stmt},
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ResolverError {
     OwnInitializer(Token),
 }
@@ -165,6 +165,21 @@ impl<'a> Resolver<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compiler::{interpreter, lexer, parser};
+
+    #[test]
+    fn own_decl_error() {
+        let source = "var a = \"init\"; {var a = a;}";
+        let tokens = lexer::scan_source(&source.to_string()).unwrap();
+        let program = parser::program(tokens, source.to_string());
+        let mut interp = interpreter::Interpreter::new();
+        let mut res = Resolver::new(&mut interp);
+        res.resolve(&program.statements);
+        assert_eq!(
+            res.errors.first().expect("one error"),
+            &ResolverError::OwnInitializer(Token::identifier("a".to_string()))
+        )
+    }
 
     #[test]
     fn declare_define() {

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -138,7 +138,20 @@ impl<'a> Resolver<'a> {
         Ok(())
     }
 
-    fn resolve_local(&mut self, expression: &Expr, name: &String) {}
+    fn resolve_local(&mut self, expression: &Expr, name: &String) {
+        let mut i = self.scopes.len() as i32 - 1;
+        while i >= 0 {
+            if self
+                .scopes
+                .get(i as usize)
+                .is_some_and(|s| s.borrow().get(name).is_some())
+            {
+                self.interpreter
+                    .resolve(expression, self.scopes.len() - 1 - i as usize)
+            }
+            i = i - 1;
+        }
+    }
 
     fn begin_scope(&mut self) {
         let _ = &self.scopes.push(RefCell::new(HashMap::new()));

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -139,7 +139,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_local(&mut self, expression: &Expr, name: &String) {
-        let mut i = self.scopes.len() as i32 - 1;
+        let mut i = self.scopes.len() as i32;
         while i >= 0 {
             if self
                 .scopes
@@ -147,7 +147,8 @@ impl<'a> Resolver<'a> {
                 .is_some_and(|s| s.borrow().get(name).is_some())
             {
                 self.interpreter
-                    .resolve(expression, self.scopes.len() - 1 - i as usize)
+                    .resolve(expression, self.scopes.len() - 1 - i as usize);
+                return;
             }
             i = i - 1;
         }

--- a/src/compiler/resolver.rs
+++ b/src/compiler/resolver.rs
@@ -213,6 +213,10 @@ mod tests {
         let mut res = Resolver::new(&mut interp);
         res.resolve(&program.statements);
         assert!(!res.errors.is_empty());
+        assert_eq!(
+            res.errors.first().expect("one error"),
+            &ResolverError::Redefinition(Token::identifier("a".to_string()))
+        )
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn execute(source: &String, interp: &mut interpreter::Interpreter, show_ast: boo
         }
         return;
     }
-    let mut res = resolver::Resolver::new(&interp);
+    let mut res = resolver::Resolver::new(interp);
     res.resolve(&program.statements);
 
     interp.run(&program);

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,13 @@ fn execute(source: &String, interp: &mut interpreter::Interpreter, show_ast: boo
     }
     let mut res = resolver::Resolver::new(interp);
     res.resolve(&program.statements);
+    if !res.errors.is_empty() {
+        for error in res.errors.iter() {
+            // TODO: implement report for resolver errors
+            dbg!(&error);
+        }
+        return;
+    }
 
     interp.run(&program);
     interp.flush();

--- a/tests/static_scope.lox
+++ b/tests/static_scope.lox
@@ -1,0 +1,13 @@
+var a = "global";
+{
+    fun showA() {
+        print a;
+    }
+
+    showA();
+    var a = "block";
+    showA();
+}
+// once chapter 11 is complete, this should output
+// global
+// global


### PR DESCRIPTION
# Resolver Implementation

Implements chapter 11 well enough.

- **start chapter 11 with failing unit test from book**
- **start outline of resolver**
- **make ident() function for Token public - moved from environment helper**
- **Token::ident() returns &String instead of owned String**
- **resolver: implement through 11.3.5**
- **resolver: implement through 11.3**
- **hook up resolver so that it runs prior to interpreter. Work in progress.**
- **tests: add check_error helper that prints resolver/parser errors before failing**
- **resolver functions now implement ResolverError**
- **fix resolver variable expression logic**
- **add hash function for Token**
- **add resolve function and locals to interpreter**
- **add get_at and set_at environment functions**
- **tests: get_at and set_at**
- **tests: resolver declare & define**
- **tests: resolver own declaration error**
- **add redefinition error to resolver + test case**
- **Hook up resolver, almost working**
- **minor clean-up**
- **Fix: make resolver scopes FIFO**
- **Final fixes to resolver, scope tests passing**
- **tests: specify expected resolver redefinition error**
- **add error and test for return outside of function**
- **implement error + tests for break statement outside of loop**
- **hook up resolver to main**
